### PR TITLE
Add client metadata methods to API documentation

### DIFF
--- a/api/server.md
+++ b/api/server.md
@@ -202,6 +202,31 @@ if ($type === 'ws') {
 }
 ```
 
+### Client metadata methods
+
+```php
+public function allData(string $clientId): ?array
+public function data(string $clientId, string $key): mixed
+public function putData(string $clientId, string $key, mixed $value): void
+public function hasData(string $clientId, string $key): bool
+public function forgetData(string $clientId, ?string $key = null): void
+```
+
+`allData()` returns the full data bag for a connection. `data()` reads a single key. `forgetData()` removes one key, or all data when `$key` is omitted.
+
+**Example:**
+```php
+$server->putData($clientId, 'authenticated', true);
+$server->putData($clientId, 'role', 'admin');
+
+if ($server->hasData($clientId, 'authenticated')) {
+    $role = $server->data($clientId, 'role');
+}
+
+$bag = $server->allData($clientId);
+$server->forgetData($clientId, 'role');
+```
+
 ---
 
 ## Communication Methods

--- a/core/middleware.md
+++ b/core/middleware.md
@@ -261,7 +261,7 @@ class WebSocketAuthMiddleware implements WebsocketMiddleware
     private function isClientAuthenticated(string $clientId, Server $server): bool
     {
         // Check authentication status (you'd implement this)
-        $clientData = $server->getClientData($clientId);
+        $clientData = $server->allData($clientId);
         return isset($clientData['authenticated']) && $clientData['authenticated'] === true;
     }
 }
@@ -490,8 +490,8 @@ class WebSocketAuthHandshakeMiddleware implements HandshakeMiddleware
         }
 
         // Store auth info for later use
-        $server->setClientData($clientId, 'authenticated', true);
-        $server->setClientData($clientId, 'token', $token);
+        $server->putData($clientId, 'authenticated', true);
+        $server->putData($clientId, 'token', $token);
 
         return $next($clientId, $request);
     }

--- a/getting-started/migration-v3.md
+++ b/getting-started/migration-v3.md
@@ -250,9 +250,10 @@ return [
 | `disconnectClient()` | `disconnect()` | Controller |
 | `isClientConnected()` | `isConnected()` | Controller |
 | `getClientIpAddress()` | `getClientIp()` | Controller |
-| `getClientData()` | `data()` / `allData()` | Controller |
-| `setClientData()` | `putData()` | Controller |
-| `hasClientData()` | `hasData()` | Controller |
+| `getClientData()` | `data()` / `allData()` | Controller / Server |
+| `setClientData()` | `putData()` | Controller / Server |
+| `hasClientData()` | `hasData()` | Controller / Server |
+| `forgetClientData()` | `forgetData()` | Server |
 | `forgetData()` | new in 3.x | Controller |
 
 Run `vendor/bin/sockeon-upgrade` to apply most of these automatically.


### PR DESCRIPTION
- Introduced new methods for managing client metadata: `allData()`, `data()`, `putData()`, `hasData()`, and `forgetData()`.
- Updated middleware to utilize the new methods for client data management.
- Revised migration guide to reflect changes in client data handling methods.